### PR TITLE
pedantic markdown syntax update + "H" in github

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
-Codecov
-=======
+# Codecov
+
 > This repository is for press and marketing support. Please contact hello@codecov.io for questions and comments. Thanks!
 
 ## Branding
@@ -23,7 +23,7 @@ Codecov
 ## Bookmarks
 
 ### Social and Marketing
-- [Github](https://github.com/codecov)
+- [GitHub](https://github.com/codecov)
 - [Twitter](https://twitter.com/codecov)
 - [Google+](https://plus.google.com/u/0/b/104298400123069697768/)
 - [LinkedIn](https://www.linkedin.com/company/codecov)


### PR DESCRIPTION
:wave: @stevepeak!

These aren't really super important changes but ones that caught my eye regardless. 😃 

## Changes
- change markdown syntax of an `<h1>` element to be [ATX heading](http://www.aaronsw.com/2002/atx/intro) vs [SETEXT](http://docutils.sourceforge.net/mirror/setext.html) like the rest of the headers.
- Capital H in "GitHub"